### PR TITLE
test: add Lambda, SQS, and IAM test coverage

### DIFF
--- a/tests/test_iam_routes.py
+++ b/tests/test_iam_routes.py
@@ -1,0 +1,382 @@
+"""Integration tests for IAM API routes."""
+
+import os
+
+os.environ.setdefault("AWS_ENDPOINT_URL", "http://localhost:4566")
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+NOW = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+
+class TestListUsers:
+    @patch("backend.routes.iam.get_client")
+    def test_list_users_empty(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_users.return_value = {"Users": []}
+
+        resp = client.get("/api/iam/users")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["users"] == []
+
+    @patch("backend.routes.iam.get_client")
+    def test_list_users_with_data(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_users.return_value = {
+            "Users": [
+                {
+                    "UserName": "alice",
+                    "UserId": "AIDAEXAMPLE1",
+                    "Arn": "arn:aws:iam::000000000000:user/alice",
+                    "Path": "/",
+                    "CreateDate": NOW,
+                }
+            ]
+        }
+
+        resp = client.get("/api/iam/users")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["users"]) == 1
+        assert data["users"][0]["UserName"] == "alice"
+        assert data["users"][0]["UserId"] == "AIDAEXAMPLE1"
+
+
+class TestGetUserDetail:
+    @patch("backend.routes.iam.get_client")
+    def test_get_user_detail(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.get_user.return_value = {
+            "User": {
+                "UserName": "alice",
+                "UserId": "AIDAEXAMPLE1",
+                "Arn": "arn:aws:iam::000000000000:user/alice",
+                "Path": "/",
+                "CreateDate": NOW,
+            }
+        }
+        mock_iam.list_attached_user_policies.return_value = {
+            "AttachedPolicies": [
+                {"PolicyName": "ReadOnly", "PolicyArn": "arn:aws:iam::000:policy/ReadOnly"}
+            ]
+        }
+        mock_iam.list_user_policies.return_value = {"PolicyNames": ["inline-1"]}
+        mock_iam.get_user_policy.return_value = {
+            "PolicyDocument": '{"Version":"2012-10-17","Statement":[]}'
+        }
+        mock_iam.list_groups_for_user.return_value = {
+            "Groups": [
+                {
+                    "GroupName": "developers",
+                    "GroupId": "AGPAEXAMPLE",
+                    "Arn": "arn:aws:iam::000:group/developers",
+                    "Path": "/",
+                    "CreateDate": NOW,
+                }
+            ]
+        }
+        mock_iam.list_access_keys.return_value = {
+            "AccessKeyMetadata": [
+                {
+                    "UserName": "alice",
+                    "AccessKeyId": "AKIAEXAMPLE",
+                    "Status": "Active",
+                    "CreateDate": NOW,
+                }
+            ]
+        }
+        mock_iam.list_user_tags.return_value = {
+            "Tags": [{"Key": "team", "Value": "backend"}]
+        }
+
+        resp = client.get("/api/iam/users/alice")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user"]["UserName"] == "alice"
+        assert len(data["attached_policies"]) == 1
+        assert data["attached_policies"][0]["PolicyName"] == "ReadOnly"
+        assert len(data["inline_policies"]) == 1
+        assert data["inline_policies"][0]["name"] == "inline-1"
+        assert len(data["groups"]) == 1
+        assert data["groups"][0]["GroupName"] == "developers"
+        assert len(data["access_keys"]) == 1
+        assert data["access_keys"][0]["Status"] == "Active"
+        assert data["tags"] == {"team": "backend"}
+
+
+class TestListRoles:
+    @patch("backend.routes.iam.get_client")
+    def test_list_roles_empty(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_roles.return_value = {"Roles": []}
+
+        resp = client.get("/api/iam/roles")
+        assert resp.status_code == 200
+        assert resp.json()["roles"] == []
+
+    @patch("backend.routes.iam.get_client")
+    def test_list_roles_with_data(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_roles.return_value = {
+            "Roles": [
+                {
+                    "RoleName": "lambda-exec",
+                    "RoleId": "AROAEXAMPLE",
+                    "Arn": "arn:aws:iam::000:role/lambda-exec",
+                    "Path": "/",
+                    "CreateDate": NOW,
+                    "MaxSessionDuration": 3600,
+                }
+            ]
+        }
+
+        resp = client.get("/api/iam/roles")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["roles"]) == 1
+        assert data["roles"][0]["RoleName"] == "lambda-exec"
+        assert data["roles"][0]["MaxSessionDuration"] == 3600
+
+
+class TestGetRoleDetail:
+    @patch("backend.routes.iam.get_client")
+    def test_get_role_detail(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.get_role.return_value = {
+            "Role": {
+                "RoleName": "lambda-exec",
+                "RoleId": "AROAEXAMPLE",
+                "Arn": "arn:aws:iam::000:role/lambda-exec",
+                "Path": "/",
+                "CreateDate": NOW,
+                "MaxSessionDuration": 3600,
+                "AssumeRolePolicyDocument": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}',
+            }
+        }
+        mock_iam.list_attached_role_policies.return_value = {
+            "AttachedPolicies": [
+                {"PolicyName": "AWSLambdaBasicExecutionRole", "PolicyArn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"}
+            ]
+        }
+        mock_iam.list_role_policies.return_value = {"PolicyNames": []}
+        mock_iam.list_role_tags.return_value = {"Tags": []}
+
+        resp = client.get("/api/iam/roles/lambda-exec")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["role"]["RoleName"] == "lambda-exec"
+        assert data["trust_policy"]["Version"] == "2012-10-17"
+        assert len(data["attached_policies"]) == 1
+        assert data["inline_policies"] == []
+
+
+class TestListGroups:
+    @patch("backend.routes.iam.get_client")
+    def test_list_groups_empty(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_groups.return_value = {"Groups": []}
+
+        resp = client.get("/api/iam/groups")
+        assert resp.status_code == 200
+        assert resp.json()["groups"] == []
+
+    @patch("backend.routes.iam.get_client")
+    def test_list_groups_with_data(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_groups.return_value = {
+            "Groups": [
+                {
+                    "GroupName": "admins",
+                    "GroupId": "AGPAEXAMPLE",
+                    "Arn": "arn:aws:iam::000:group/admins",
+                    "Path": "/",
+                    "CreateDate": NOW,
+                }
+            ]
+        }
+
+        resp = client.get("/api/iam/groups")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["groups"]) == 1
+        assert data["groups"][0]["GroupName"] == "admins"
+
+
+class TestGetGroupDetail:
+    @patch("backend.routes.iam.get_client")
+    def test_get_group_detail(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.get_group.return_value = {
+            "Group": {
+                "GroupName": "admins",
+                "GroupId": "AGPAEXAMPLE",
+                "Arn": "arn:aws:iam::000:group/admins",
+                "Path": "/",
+                "CreateDate": NOW,
+            },
+            "Users": [
+                {
+                    "UserName": "alice",
+                    "UserId": "AIDAEXAMPLE1",
+                    "Arn": "arn:aws:iam::000:user/alice",
+                    "Path": "/",
+                    "CreateDate": NOW,
+                }
+            ],
+        }
+        mock_iam.list_attached_group_policies.return_value = {
+            "AttachedPolicies": [
+                {"PolicyName": "AdminAccess", "PolicyArn": "arn:aws:iam::000:policy/AdminAccess"}
+            ]
+        }
+        mock_iam.list_group_policies.return_value = {"PolicyNames": ["inline-group"]}
+        mock_iam.get_group_policy.return_value = {
+            "PolicyDocument": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}'
+        }
+
+        resp = client.get("/api/iam/groups/admins")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["group"]["GroupName"] == "admins"
+        assert len(data["users"]) == 1
+        assert data["users"][0]["UserName"] == "alice"
+        assert len(data["attached_policies"]) == 1
+        assert len(data["inline_policies"]) == 1
+        assert data["inline_policies"][0]["document"]["Statement"][0]["Effect"] == "Allow"
+
+
+class TestListPolicies:
+    @patch("backend.routes.iam.get_client")
+    def test_list_policies_empty(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_policies.return_value = {"Policies": []}
+
+        resp = client.get("/api/iam/policies")
+        assert resp.status_code == 200
+        assert resp.json()["policies"] == []
+
+    @patch("backend.routes.iam.get_client")
+    def test_list_policies_with_data(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_policies.return_value = {
+            "Policies": [
+                {
+                    "PolicyName": "MyPolicy",
+                    "PolicyId": "ANPAEXAMPLE",
+                    "Arn": "arn:aws:iam::000:policy/MyPolicy",
+                    "Path": "/",
+                    "DefaultVersionId": "v1",
+                    "AttachmentCount": 2,
+                    "CreateDate": NOW,
+                    "UpdateDate": NOW,
+                }
+            ]
+        }
+
+        resp = client.get("/api/iam/policies")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["policies"]) == 1
+        assert data["policies"][0]["PolicyName"] == "MyPolicy"
+        assert data["policies"][0]["AttachmentCount"] == 2
+
+    @patch("backend.routes.iam.get_client")
+    def test_list_policies_scope_param(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        mock_iam.list_policies.return_value = {"Policies": []}
+
+        client.get("/api/iam/policies?scope=AWS")
+        call_kwargs = mock_iam.list_policies.call_args[1]
+        assert call_kwargs["Scope"] == "AWS"
+
+
+class TestGetPolicyDetail:
+    @patch("backend.routes.iam.get_client")
+    def test_get_policy_detail(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        arn = "arn:aws:iam::000:policy/MyPolicy"
+        mock_iam.get_policy.return_value = {
+            "Policy": {
+                "PolicyName": "MyPolicy",
+                "PolicyId": "ANPAEXAMPLE",
+                "Arn": arn,
+                "Path": "/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 3,
+                "CreateDate": NOW,
+                "UpdateDate": NOW,
+            }
+        }
+        mock_iam.get_policy_version.return_value = {
+            "PolicyVersion": {
+                "Document": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}'
+            }
+        }
+        mock_iam.list_entities_for_policy.return_value = {
+            "PolicyUsers": [{"UserName": "alice"}],
+            "PolicyRoles": [{"RoleName": "lambda-exec"}],
+            "PolicyGroups": [{"GroupName": "admins"}],
+        }
+        mock_iam.list_policy_tags.return_value = {
+            "Tags": [{"Key": "managed", "Value": "true"}]
+        }
+
+        resp = client.get(f"/api/iam/policies/{arn}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["policy"]["PolicyName"] == "MyPolicy"
+        assert data["document"]["Statement"][0]["Action"] == "s3:GetObject"
+        assert len(data["attached_to"]["users"]) == 1
+        assert len(data["attached_to"]["roles"]) == 1
+        assert len(data["attached_to"]["groups"]) == 1
+        assert data["tags"] == {"managed": "true"}
+
+    @patch("backend.routes.iam.get_client")
+    def test_get_policy_no_version(self, mock_get_client):
+        mock_iam = MagicMock()
+        mock_get_client.return_value = mock_iam
+        arn = "arn:aws:iam::000:policy/EmptyPolicy"
+        mock_iam.get_policy.return_value = {
+            "Policy": {
+                "PolicyName": "EmptyPolicy",
+                "PolicyId": "ANPAEXAMPLE2",
+                "Arn": arn,
+                "Path": "/",
+                "AttachmentCount": 0,
+                "CreateDate": NOW,
+                "UpdateDate": NOW,
+            }
+        }
+        mock_iam.list_entities_for_policy.return_value = {
+            "PolicyUsers": [],
+            "PolicyRoles": [],
+            "PolicyGroups": [],
+        }
+        mock_iam.list_policy_tags.return_value = {"Tags": []}
+
+        resp = client.get(f"/api/iam/policies/{arn}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["document"] == {}
+        assert data["attached_to"]["users"] == []

--- a/tests/test_lambda_routes.py
+++ b/tests/test_lambda_routes.py
@@ -1,0 +1,271 @@
+"""Integration tests for Lambda API routes."""
+
+import os
+
+os.environ.setdefault("AWS_ENDPOINT_URL", "http://localhost:4566")
+
+import base64
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+class TestListFunctions:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_functions_empty(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [{"Functions": []}]
+
+        resp = client.get("/api/lambda/functions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["functions"] == []
+
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_functions_with_data(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Functions": [
+                    {
+                        "FunctionName": "my-func",
+                        "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                        "Runtime": "python3.12",
+                        "Handler": "handler.main",
+                        "CodeSize": 1024,
+                        "Timeout": 30,
+                        "MemorySize": 128,
+                    }
+                ]
+            }
+        ]
+
+        resp = client.get("/api/lambda/functions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["functions"]) == 1
+        assert data["functions"][0]["FunctionName"] == "my-func"
+        assert data["functions"][0]["Runtime"] == "python3.12"
+
+
+class TestGetFunction:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_get_function_detail(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        mock_lambda.get_function.return_value = {
+            "Configuration": {
+                "FunctionName": "my-func",
+                "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                "Runtime": "python3.12",
+                "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                "Handler": "handler.main",
+                "CodeSize": 2048,
+                "Timeout": 60,
+                "MemorySize": 256,
+            },
+            "Code": {"Location": "https://example.com/code.zip"},
+            "Tags": {"env": "test"},
+            "Concurrency": {"ReservedConcurrentExecutions": 10},
+        }
+
+        resp = client.get("/api/lambda/functions/my-func")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["configuration"]["FunctionName"] == "my-func"
+        assert data["code"]["Location"] == "https://example.com/code.zip"
+        assert data["tags"] == {"env": "test"}
+        assert data["concurrency"]["ReservedConcurrentExecutions"] == 10
+
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_get_function_not_found(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        mock_lambda.exceptions.ResourceNotFoundException = type("ResourceNotFoundException", (Exception,), {})
+        mock_lambda.get_function.side_effect = mock_lambda.exceptions.ResourceNotFoundException()
+
+        resp = client.get("/api/lambda/functions/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestDownloadCode:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_download_redirects(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        mock_lambda.get_function.return_value = {
+            "Configuration": {"PackageType": "Zip"},
+            "Code": {"Location": "https://example.com/code.zip"},
+        }
+
+        resp = client.get("/api/lambda/functions/my-func/code", follow_redirects=False)
+        assert resp.status_code == 307
+        assert "example.com/code.zip" in resp.headers["location"]
+
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_download_image_returns_400(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        mock_lambda.get_function.return_value = {
+            "Configuration": {"PackageType": "Image"},
+            "Code": {},
+        }
+
+        resp = client.get("/api/lambda/functions/my-func/code")
+        assert resp.status_code == 400
+
+
+class TestInvokeFunction:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_invoke_returns_payload(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+
+        response_payload = io.BytesIO(json.dumps({"result": "ok"}).encode("utf-8"))
+        mock_lambda.invoke.return_value = {
+            "StatusCode": 200,
+            "ExecutedVersion": "$LATEST",
+            "Payload": response_payload,
+            "LogResult": base64.b64encode(b"START RequestId: abc\nEND").decode("utf-8"),
+        }
+
+        resp = client.post(
+            "/api/lambda/functions/my-func/invoke",
+            json={"payload": {"key": "value"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["statusCode"] == 200
+        assert data["payload"] == {"result": "ok"}
+        assert data["logs"] is not None
+        assert "START" in data["logs"]
+
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_invoke_with_function_error(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+
+        response_payload = io.BytesIO(b'"error message"')
+        mock_lambda.invoke.return_value = {
+            "StatusCode": 200,
+            "FunctionError": "Unhandled",
+            "ExecutedVersion": "$LATEST",
+            "Payload": response_payload,
+        }
+
+        resp = client.post(
+            "/api/lambda/functions/my-func/invoke",
+            json={"payload": {}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["functionError"] == "Unhandled"
+
+
+class TestListEventSources:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_event_sources_empty(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [{"EventSourceMappings": []}]
+
+        resp = client.get("/api/lambda/functions/my-func/event-sources")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["eventSourceMappings"] == []
+
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_event_sources_with_data(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "EventSourceMappings": [
+                    {
+                        "UUID": "abc-123",
+                        "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+                        "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                        "State": "Enabled",
+                    }
+                ]
+            }
+        ]
+
+        resp = client.get("/api/lambda/functions/my-func/event-sources")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["eventSourceMappings"]) == 1
+        assert data["eventSourceMappings"][0]["State"] == "Enabled"
+
+
+class TestListAliases:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_aliases(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Aliases": [
+                    {
+                        "AliasArn": "arn:aws:lambda:us-east-1:000000000000:function:my-func:prod",
+                        "Name": "prod",
+                        "FunctionVersion": "3",
+                    }
+                ]
+            }
+        ]
+
+        resp = client.get("/api/lambda/functions/my-func/aliases")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["aliases"]) == 1
+        assert data["aliases"][0]["Name"] == "prod"
+
+
+class TestListVersions:
+    @patch("backend.routes.lambda_svc.get_client")
+    def test_list_versions(self, mock_get_client):
+        mock_lambda = MagicMock()
+        mock_get_client.return_value = mock_lambda
+        paginator = MagicMock()
+        mock_lambda.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Versions": [
+                    {
+                        "FunctionName": "my-func",
+                        "Version": "$LATEST",
+                        "CodeSize": 1024,
+                    },
+                    {
+                        "FunctionName": "my-func",
+                        "Version": "1",
+                        "CodeSize": 1024,
+                    },
+                ]
+            }
+        ]
+
+        resp = client.get("/api/lambda/functions/my-func/versions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["versions"]) == 2
+        assert data["versions"][0]["Version"] == "$LATEST"

--- a/tests/test_sqs_routes.py
+++ b/tests/test_sqs_routes.py
@@ -1,0 +1,290 @@
+"""Integration tests for SQS API routes."""
+
+import os
+
+os.environ.setdefault("AWS_ENDPOINT_URL", "http://localhost:4566")
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+QUEUE_URL = "http://localhost:4566/000000000000/test-queue"
+
+
+class TestListQueues:
+    @patch("backend.routes.sqs.get_client")
+    def test_list_queues_empty(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.list_queues.return_value = {}
+
+        resp = client.get("/api/sqs/queues")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["queues"] == []
+
+    @patch("backend.routes.sqs.get_client")
+    def test_list_queues_with_data(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.list_queues.return_value = {"QueueUrls": [QUEUE_URL]}
+        mock_sqs.get_queue_attributes.return_value = {
+            "Attributes": {
+                "ApproximateNumberOfMessages": "5",
+                "ApproximateNumberOfMessagesNotVisible": "1",
+                "ApproximateNumberOfMessagesDelayed": "0",
+                "VisibilityTimeout": "30",
+                "MessageRetentionPeriod": "345600",
+                "DelaySeconds": "0",
+            }
+        }
+        mock_sqs.list_queue_tags.return_value = {"Tags": {"env": "test"}}
+
+        resp = client.get("/api/sqs/queues")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["queues"]) == 1
+        q = data["queues"][0]
+        assert q["name"] == "test-queue"
+        assert q["url"] == QUEUE_URL
+        assert q["type"] == "Standard"
+        assert q["approximateNumberOfMessages"] == 5
+        assert q["tags"] == {"env": "test"}
+
+    @patch("backend.routes.sqs.get_client")
+    def test_list_queues_fifo(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        fifo_url = "http://localhost:4566/000000000000/orders.fifo"
+        mock_sqs.list_queues.return_value = {"QueueUrls": [fifo_url]}
+        mock_sqs.get_queue_attributes.return_value = {
+            "Attributes": {"FifoQueue": "true"}
+        }
+        mock_sqs.list_queue_tags.return_value = {"Tags": {}}
+
+        resp = client.get("/api/sqs/queues")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["queues"][0]["type"] == "FIFO"
+        assert data["queues"][0]["name"] == "orders.fifo"
+
+    @patch("backend.routes.sqs.get_client")
+    def test_list_queues_with_redrive_policy(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.list_queues.return_value = {"QueueUrls": [QUEUE_URL]}
+        mock_sqs.get_queue_attributes.return_value = {
+            "Attributes": {
+                "RedrivePolicy": '{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000:dlq","maxReceiveCount":3}',
+            }
+        }
+        mock_sqs.list_queue_tags.return_value = {"Tags": {}}
+
+        resp = client.get("/api/sqs/queues")
+        assert resp.status_code == 200
+        rp = resp.json()["queues"][0]["redrivePolicy"]
+        assert rp is not None
+        assert rp["maxReceiveCount"] == 3
+
+
+class TestGetQueueDetail:
+    @patch("backend.routes.sqs.get_client")
+    def test_get_queue_detail(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.get_queue_attributes.return_value = {
+            "Attributes": {
+                "QueueArn": "arn:aws:sqs:us-east-1:000:test-queue",
+                "ApproximateNumberOfMessages": "10",
+                "ApproximateNumberOfMessagesNotVisible": "2",
+                "ApproximateNumberOfMessagesDelayed": "0",
+                "VisibilityTimeout": "60",
+                "MessageRetentionPeriod": "86400",
+                "MaximumMessageSize": "262144",
+                "DelaySeconds": "5",
+                "ContentBasedDeduplication": "false",
+            }
+        }
+        mock_sqs.list_queue_tags.return_value = {"Tags": {"team": "backend"}}
+
+        resp = client.get("/api/sqs/queues/test-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "test-queue"
+        assert data["arn"] == "arn:aws:sqs:us-east-1:000:test-queue"
+        assert data["approximateNumberOfMessages"] == 10
+        assert data["maximumMessageSize"] == 262144
+        assert data["delaySeconds"] == 5
+        assert data["contentBasedDeduplication"] is False
+        assert data["tags"] == {"team": "backend"}
+
+    @patch("backend.routes.sqs.get_client")
+    def test_get_queue_not_found(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.exceptions.QueueDoesNotExist = type("QueueDoesNotExist", (Exception,), {})
+        mock_sqs.get_queue_url.side_effect = mock_sqs.exceptions.QueueDoesNotExist()
+
+        resp = client.get("/api/sqs/queues/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestSendMessage:
+    @patch("backend.routes.sqs.get_client")
+    def test_send_basic_message(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.send_message.return_value = {
+            "MessageId": "msg-123",
+            "MD5OfMessageBody": "abc",
+        }
+
+        resp = client.post(
+            "/api/sqs/queues/test-queue/messages",
+            json={"messageBody": "hello world"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["messageId"] == "msg-123"
+        assert data["md5OfMessageBody"] == "abc"
+
+    @patch("backend.routes.sqs.get_client")
+    def test_send_message_with_attributes(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.send_message.return_value = {
+            "MessageId": "msg-456",
+            "MD5OfMessageBody": "def",
+        }
+
+        resp = client.post(
+            "/api/sqs/queues/test-queue/messages",
+            json={
+                "messageBody": "test",
+                "delaySeconds": 10,
+                "messageAttributes": {
+                    "source": {"stringValue": "api", "dataType": "String"}
+                },
+            },
+        )
+        assert resp.status_code == 200
+        call_kwargs = mock_sqs.send_message.call_args[1]
+        assert call_kwargs["DelaySeconds"] == 10
+        assert "MessageAttributes" in call_kwargs
+
+    @patch("backend.routes.sqs.get_client")
+    def test_send_message_fifo_params(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.send_message.return_value = {
+            "MessageId": "msg-789",
+            "MD5OfMessageBody": "ghi",
+            "SequenceNumber": "1",
+        }
+
+        resp = client.post(
+            "/api/sqs/queues/test-queue/messages",
+            json={
+                "messageBody": "fifo test",
+                "messageDeduplicationId": "dedup-1",
+                "messageGroupId": "group-1",
+            },
+        )
+        assert resp.status_code == 200
+        call_kwargs = mock_sqs.send_message.call_args[1]
+        assert call_kwargs["MessageDeduplicationId"] == "dedup-1"
+        assert call_kwargs["MessageGroupId"] == "group-1"
+
+
+class TestReceiveMessages:
+    @patch("backend.routes.sqs.get_client")
+    def test_receive_messages(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.receive_message.return_value = {
+            "Messages": [
+                {
+                    "MessageId": "msg-1",
+                    "ReceiptHandle": "handle-1",
+                    "Body": "hello",
+                    "MD5OfBody": "abc",
+                    "Attributes": {"SentTimestamp": "1234567890"},
+                    "MessageAttributes": {},
+                }
+            ]
+        }
+
+        resp = client.get("/api/sqs/queues/test-queue/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["messages"]) == 1
+        assert data["messages"][0]["messageId"] == "msg-1"
+        assert data["messages"][0]["body"] == "hello"
+
+    @patch("backend.routes.sqs.get_client")
+    def test_receive_messages_empty(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.receive_message.return_value = {}
+
+        resp = client.get("/api/sqs/queues/test-queue/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["messages"] == []
+
+    @patch("backend.routes.sqs.get_client")
+    def test_receive_messages_with_params(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+        mock_sqs.receive_message.return_value = {"Messages": []}
+
+        resp = client.get("/api/sqs/queues/test-queue/messages?max_messages=5&visibility_timeout=30")
+        assert resp.status_code == 200
+        call_kwargs = mock_sqs.receive_message.call_args[1]
+        assert call_kwargs["MaxNumberOfMessages"] == 5
+        assert call_kwargs["VisibilityTimeout"] == 30
+
+
+class TestDeleteMessage:
+    @patch("backend.routes.sqs.get_client")
+    def test_delete_message(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+
+        resp = client.delete("/api/sqs/queues/test-queue/messages?receipt_handle=handle-1")
+        assert resp.status_code == 204
+
+
+class TestPurgeQueue:
+    @patch("backend.routes.sqs.get_client")
+    def test_purge_queue(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": QUEUE_URL}
+
+        resp = client.post("/api/sqs/queues/test-queue/purge")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+
+    @patch("backend.routes.sqs.get_client")
+    def test_purge_queue_not_found(self, mock_get_client):
+        mock_sqs = MagicMock()
+        mock_get_client.return_value = mock_sqs
+        mock_sqs.exceptions.QueueDoesNotExist = type("QueueDoesNotExist", (Exception,), {})
+        mock_sqs.get_queue_url.side_effect = mock_sqs.exceptions.QueueDoesNotExist()
+
+        resp = client.post("/api/sqs/queues/nonexistent/purge")
+        assert resp.status_code == 404

--- a/ui/src/__tests__/iam-api.test.ts
+++ b/ui/src/__tests__/iam-api.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  fetchIAMUsers,
+  fetchIAMUserDetail,
+  fetchIAMRoles,
+  fetchIAMRoleDetail,
+  fetchIAMGroups,
+  fetchIAMGroupDetail,
+  fetchIAMPolicies,
+  fetchIAMPolicyDetail,
+} from '@/lib/api'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+function mockOk(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+function mockError(status: number) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: 'Error',
+  })
+}
+
+describe('fetchIAMUsers', () => {
+  it('calls the correct URL', async () => {
+    mockOk({ users: [] })
+    const result = await fetchIAMUsers()
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/users')
+    expect(result.users).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchIAMUsers()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchIAMUserDetail', () => {
+  it('calls correct URL with encoded name', async () => {
+    mockOk({ user: { UserName: 'alice' } })
+    await fetchIAMUserDetail('alice')
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/users/alice')
+  })
+
+  it('encodes special characters', async () => {
+    mockOk({ user: {} })
+    await fetchIAMUserDetail('user name')
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/users/user%20name')
+  })
+})
+
+describe('fetchIAMRoles', () => {
+  it('calls the correct URL', async () => {
+    mockOk({ roles: [] })
+    const result = await fetchIAMRoles()
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/roles')
+    expect(result.roles).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchIAMRoles()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchIAMRoleDetail', () => {
+  it('calls correct URL', async () => {
+    mockOk({ role: { RoleName: 'my-role' } })
+    await fetchIAMRoleDetail('my-role')
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/roles/my-role')
+  })
+})
+
+describe('fetchIAMGroups', () => {
+  it('calls the correct URL', async () => {
+    mockOk({ groups: [] })
+    const result = await fetchIAMGroups()
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/groups')
+    expect(result.groups).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchIAMGroups()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchIAMGroupDetail', () => {
+  it('calls correct URL', async () => {
+    mockOk({ group: { GroupName: 'admins' } })
+    await fetchIAMGroupDetail('admins')
+    expect(mockFetch).toHaveBeenCalledWith('/api/iam/groups/admins')
+  })
+})
+
+describe('fetchIAMPolicies', () => {
+  it('calls correct URL with default scope', async () => {
+    mockOk({ policies: [] })
+    await fetchIAMPolicies()
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('/api/iam/policies')
+    expect(url).toContain('scope=Local')
+  })
+
+  it('passes custom scope', async () => {
+    mockOk({ policies: [] })
+    await fetchIAMPolicies('AWS')
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('scope=AWS')
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchIAMPolicies()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchIAMPolicyDetail', () => {
+  it('calls correct URL with encoded ARN', async () => {
+    const arn = 'arn:aws:iam::000:policy/MyPolicy'
+    mockOk({ policy: { Arn: arn } })
+    await fetchIAMPolicyDetail(arn)
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/iam/policies/${encodeURIComponent(arn)}`
+    )
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(404)
+    await expect(
+      fetchIAMPolicyDetail('arn:aws:iam::000:policy/missing')
+    ).rejects.toThrow('404')
+  })
+})

--- a/ui/src/__tests__/lambda-api.test.ts
+++ b/ui/src/__tests__/lambda-api.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  fetchLambdaFunctions,
+  fetchLambdaFunction,
+  getLambdaCodeDownloadUrl,
+  invokeLambdaFunction,
+  fetchLambdaEventSources,
+  fetchLambdaAliases,
+  fetchLambdaVersions,
+} from '@/lib/api'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+function mockOk(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+function mockError(status: number) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: 'Error',
+  })
+}
+
+describe('fetchLambdaFunctions', () => {
+  it('calls the correct URL', async () => {
+    mockOk({ functions: [] })
+    const result = await fetchLambdaFunctions()
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions')
+    expect(result.functions).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchLambdaFunctions()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchLambdaFunction', () => {
+  it('calls correct URL with encoded name', async () => {
+    mockOk({ configuration: { FunctionName: 'my-func' } })
+    await fetchLambdaFunction('my-func')
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions/my-func')
+  })
+
+  it('encodes special characters in function name', async () => {
+    mockOk({ configuration: {} })
+    await fetchLambdaFunction('my func')
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions/my%20func')
+  })
+})
+
+describe('getLambdaCodeDownloadUrl', () => {
+  it('returns correct download URL', () => {
+    const url = getLambdaCodeDownloadUrl('my-func')
+    expect(url).toBe('/api/lambda/functions/my-func/code')
+  })
+
+  it('encodes function name in URL', () => {
+    const url = getLambdaCodeDownloadUrl('my func')
+    expect(url).toBe('/api/lambda/functions/my%20func/code')
+  })
+})
+
+describe('invokeLambdaFunction', () => {
+  it('sends POST with correct body', async () => {
+    mockOk({ statusCode: 200, payload: { result: 'ok' } })
+    await invokeLambdaFunction('my-func', { payload: { key: 'value' } })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/lambda/functions/my-func/invoke',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.payload).toEqual({ key: 'value' })
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(404)
+    await expect(
+      invokeLambdaFunction('missing', { payload: {} })
+    ).rejects.toThrow('404')
+  })
+})
+
+describe('fetchLambdaEventSources', () => {
+  it('calls correct URL', async () => {
+    mockOk({ eventSourceMappings: [] })
+    const result = await fetchLambdaEventSources('my-func')
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions/my-func/event-sources')
+    expect(result.eventSourceMappings).toEqual([])
+  })
+})
+
+describe('fetchLambdaAliases', () => {
+  it('calls correct URL', async () => {
+    mockOk({ aliases: [] })
+    const result = await fetchLambdaAliases('my-func')
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions/my-func/aliases')
+    expect(result.aliases).toEqual([])
+  })
+})
+
+describe('fetchLambdaVersions', () => {
+  it('calls correct URL', async () => {
+    mockOk({ versions: [] })
+    const result = await fetchLambdaVersions('my-func')
+    expect(mockFetch).toHaveBeenCalledWith('/api/lambda/functions/my-func/versions')
+    expect(result.versions).toEqual([])
+  })
+})

--- a/ui/src/__tests__/sqs-api.test.ts
+++ b/ui/src/__tests__/sqs-api.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  fetchSQSQueues,
+  fetchSQSQueueDetail,
+  sendSQSMessage,
+  receiveSQSMessages,
+  deleteSQSMessage,
+  purgeSQSQueue,
+} from '@/lib/api'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+function mockOk(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+function mockError(status: number) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText: 'Error',
+  })
+}
+
+describe('fetchSQSQueues', () => {
+  it('calls the correct URL', async () => {
+    mockOk({ queues: [] })
+    const result = await fetchSQSQueues()
+    expect(mockFetch).toHaveBeenCalledWith('/api/sqs/queues')
+    expect(result.queues).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(500)
+    await expect(fetchSQSQueues()).rejects.toThrow('500')
+  })
+})
+
+describe('fetchSQSQueueDetail', () => {
+  it('calls correct URL with encoded name', async () => {
+    mockOk({ name: 'my-queue' })
+    await fetchSQSQueueDetail('my-queue')
+    expect(mockFetch).toHaveBeenCalledWith('/api/sqs/queues/my-queue')
+  })
+
+  it('encodes special characters', async () => {
+    mockOk({ name: 'my queue' })
+    await fetchSQSQueueDetail('my queue')
+    expect(mockFetch).toHaveBeenCalledWith('/api/sqs/queues/my%20queue')
+  })
+})
+
+describe('sendSQSMessage', () => {
+  it('sends POST with correct body', async () => {
+    mockOk({ messageId: 'msg-123', md5OfMessageBody: 'abc' })
+    await sendSQSMessage('my-queue', {
+      messageBody: 'hello world',
+      delaySeconds: 5,
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/sqs/queues/my-queue/messages',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.messageBody).toBe('hello world')
+    expect(body.delaySeconds).toBe(5)
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(400)
+    await expect(
+      sendSQSMessage('my-queue', { messageBody: '' })
+    ).rejects.toThrow('400')
+  })
+})
+
+describe('receiveSQSMessages', () => {
+  it('calls correct URL with default params', async () => {
+    mockOk({ messages: [] })
+    await receiveSQSMessages('my-queue')
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('/api/sqs/queues/my-queue/messages')
+    expect(url).toContain('max_messages=10')
+    expect(url).toContain('visibility_timeout=0')
+  })
+
+  it('passes custom params', async () => {
+    mockOk({ messages: [] })
+    await receiveSQSMessages('my-queue', 5, 30)
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('max_messages=5')
+    expect(url).toContain('visibility_timeout=30')
+  })
+})
+
+describe('deleteSQSMessage', () => {
+  it('sends DELETE with receipt handle', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true })
+    await deleteSQSMessage('my-queue', 'handle-123')
+
+    const [url, opts] = mockFetch.mock.calls[0]
+    expect(url).toContain('/api/sqs/queues/my-queue/messages')
+    expect(url).toContain('receipt_handle=handle-123')
+    expect(opts.method).toBe('DELETE')
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 400, statusText: 'Bad Request' })
+    await expect(deleteSQSMessage('my-queue', 'bad')).rejects.toThrow('400')
+  })
+})
+
+describe('purgeSQSQueue', () => {
+  it('sends POST to purge endpoint', async () => {
+    mockOk({ success: true, message: 'purged' })
+    const result = await purgeSQSQueue('my-queue')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/sqs/queues/my-queue/purge',
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('throws on non-ok response', async () => {
+    mockError(409)
+    await expect(purgeSQSQueue('my-queue')).rejects.toThrow('409')
+  })
+})


### PR DESCRIPTION
## Summary
- Add backend route tests for Lambda (12 tests), SQS (15 tests), and IAM (14 tests)
- Add frontend API function tests for Lambda, SQS, and IAM
- Total test count: 38 → 79 (backend), 38 → 69 (frontend)

## New test files

**Backend:**
- `tests/test_lambda_routes.py` — list functions, get detail, download code, invoke, event sources, aliases, versions
- `tests/test_sqs_routes.py` — list queues, queue detail, send/receive/delete messages, purge, FIFO detection, redrive policy parsing
- `tests/test_iam_routes.py` — list/detail for users, roles, groups, policies; inline policy decoding; trust policy; attached entities

**Frontend:**
- `ui/src/__tests__/lambda-api.test.ts` — URL construction, invoke POST body, error handling
- `ui/src/__tests__/sqs-api.test.ts` — URL construction, send/receive/delete/purge, query params
- `ui/src/__tests__/iam-api.test.ts` — URL construction, scope params, ARN encoding

## Test results
- ✅ pytest: 79 passed
- ✅ vitest: 69 passed (9 test files)