### PR TITLE
feat: add multi-endpoint support (backend)

### DIFF
--- a/backend/aws_client.py
+++ b/backend/aws_client.py
@@ -4,18 +4,27 @@ import boto3
 
 from backend.config import (
     AWS_ACCESS_KEY_ID,
-    AWS_ENDPOINT_URL,
     AWS_REGION,
     AWS_SECRET_ACCESS_KEY,
+    DEFAULT_ENDPOINT,
 )
 
 
-@functools.lru_cache(maxsize=64)
-def get_client(service_name: str):
-    """Return a boto3 client configured for the target AWS-compatible endpoint."""
+@functools.lru_cache(maxsize=128)
+def get_client(service_name: str, endpoint_url: str | None = None):
+    """Return a boto3 client for the given service and endpoint.
+
+    Args:
+        service_name: AWS service name (e.g., "s3", "dynamodb")
+        endpoint_url: Endpoint URL to use. If None, uses DEFAULT_ENDPOINT.
+
+    Returns:
+        Configured boto3 client
+    """
+    url = endpoint_url if endpoint_url is not None else DEFAULT_ENDPOINT
     return boto3.client(
         service_name,
-        endpoint_url=AWS_ENDPOINT_URL,
+        endpoint_url=url,
         region_name=AWS_REGION,
         aws_access_key_id=AWS_ACCESS_KEY_ID,
         aws_secret_access_key=AWS_SECRET_ACCESS_KEY,

--- a/backend/config.py
+++ b/backend/config.py
@@ -13,3 +13,22 @@ STACKPORT_SERVICES: str = os.environ.get(
     "elasticmapreduce,elasticloadbalancing,elasticfilesystem,cloudfront,appsync",
 )
 LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+
+def _parse_endpoints() -> dict[str, str]:
+    """Parse STACKPORT_ENDPOINTS env var into dict."""
+    endpoints_str = os.environ.get("STACKPORT_ENDPOINTS", "")
+    if not endpoints_str:
+        # Backward compatibility: single endpoint
+        return {"default": AWS_ENDPOINT_URL}
+
+    endpoints = {}
+    for pair in endpoints_str.split(","):
+        if "=" in pair:
+            name, url = pair.split("=", 1)
+            endpoints[name.strip()] = url.strip()
+    return endpoints
+
+
+ENDPOINTS: dict[str, str] = _parse_endpoints()
+DEFAULT_ENDPOINT: str = next(iter(ENDPOINTS.values()))

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import LOG_LEVEL, STACKPORT_PORT
-from backend.routes import dynamodb, ec2, iam, lambda_svc, logs, resources, s3, secretsmanager, sqs, stats
+from backend.routes import dynamodb, ec2, endpoints, iam, lambda_svc, logs, resources, s3, secretsmanager, sqs, stats
 
 
 class HealthcheckFilter(logging.Filter):
@@ -40,6 +40,7 @@ app.add_middleware(
 )
 
 app.include_router(stats.router, prefix="/api")
+app.include_router(endpoints.router, prefix="/api")
 app.include_router(s3.router, prefix="/api/s3")
 app.include_router(dynamodb.router, prefix="/api/dynamodb")
 app.include_router(lambda_svc.router, prefix="/api/lambda", tags=["lambda"])

--- a/backend/routes/common.py
+++ b/backend/routes/common.py
@@ -1,0 +1,25 @@
+"""Common route dependencies and utilities."""
+
+from fastapi import Query
+
+from backend.config import DEFAULT_ENDPOINT, ENDPOINTS
+
+
+def get_endpoint_url(endpoint: str | None = Query(None, description="Endpoint name or URL")) -> str:
+    """Extract and validate endpoint from query params.
+
+    Args:
+        endpoint: Endpoint name (e.g., "local") or direct URL. If None, uses default.
+
+    Returns:
+        Endpoint URL to use for AWS API calls
+    """
+    if endpoint is None:
+        return DEFAULT_ENDPOINT
+
+    # Check if it's a known endpoint name
+    if endpoint in ENDPOINTS:
+        return ENDPOINTS[endpoint]
+
+    # Otherwise treat as direct URL (for flexibility)
+    return endpoint

--- a/backend/routes/endpoints.py
+++ b/backend/routes/endpoints.py
@@ -1,0 +1,33 @@
+"""Endpoints management routes."""
+
+import logging
+
+from fastapi import APIRouter
+
+from backend.aws_client import get_client
+from backend.config import ENDPOINTS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/endpoints")
+def list_endpoints():
+    """List configured endpoints with health status."""
+    results = []
+
+    for name, url in ENDPOINTS.items():
+        health = "unknown"
+        try:
+            # Quick health check - try to list S3 buckets
+            s3 = get_client("s3", url)
+            s3.list_buckets()
+            health = "healthy"
+        except Exception:
+            logger.debug("Endpoint %s (%s) unhealthy", name, url, exc_info=True)
+            health = "unhealthy"
+
+        results.append({"name": name, "url": url, "health": health})
+
+    return {"endpoints": results}

--- a/backend/routes/resources.py
+++ b/backend/routes/resources.py
@@ -1,9 +1,10 @@
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from backend.aws_client import get_client
 from backend.cache import cache
+from backend.routes.common import get_endpoint_url
 from backend.routes.stats import SERVICE_REGISTRY, _METHOD_KWARGS, _count_items
 
 logger = logging.getLogger(__name__)
@@ -161,8 +162,8 @@ def _summarize_item(item, preferred_field: str | None = None) -> dict:
 
 
 @router.get("/resources/{service}")
-def list_resources(service: str):
-    cache_key = f"resources:{service}"
+def list_resources(service: str, endpoint_url: str = Depends(get_endpoint_url)):
+    cache_key = f"{endpoint_url}:resources:{service}"
     cached = cache.get(cache_key)
     if cached is not None:
         return cached
@@ -174,7 +175,7 @@ def list_resources(service: str):
     resources: dict[str, list[dict]] = {}
     for resource_type, boto3_service, method_name, response_key in registry_entries:
         try:
-            client = get_client(boto3_service)
+            client = get_client(boto3_service, endpoint_url)
             method = getattr(client, method_name)
             kwargs = _METHOD_KWARGS.get((boto3_service, method_name), {})
             resp = method(**kwargs)
@@ -194,8 +195,8 @@ def list_resources(service: str):
 
 
 @router.get("/resources/{service}/{res_type}/{res_id:path}")
-def get_resource_detail(service: str, res_type: str, res_id: str):
-    cache_key = f"detail:{service}:{res_type}:{res_id}"
+def get_resource_detail(service: str, res_type: str, res_id: str, endpoint_url: str = Depends(get_endpoint_url)):
+    cache_key = f"{endpoint_url}:detail:{service}:{res_type}:{res_id}"
     cached = cache.get(cache_key)
     if cached is not None:
         return cached
@@ -203,7 +204,7 @@ def get_resource_detail(service: str, res_type: str, res_id: str):
     # WAFv2 get_web_acl requires Name, Scope, AND Id — resolve Id from list first
     if (service, res_type) == ("wafv2", "web_acls"):
         try:
-            client = get_client("wafv2")
+            client = get_client("wafv2", endpoint_url)
             acls = client.list_web_acls(Scope="REGIONAL").get("WebACLs", [])
             match = next((a for a in acls if a.get("Name") == res_id), None)
             if not match:
@@ -236,7 +237,7 @@ def get_resource_detail(service: str, res_type: str, res_id: str):
     }
 
     try:
-        client = get_client(boto3_service)
+        client = get_client(boto3_service, endpoint_url)
         method = getattr(client, method_name)
         if id_param in _LIST_PARAMS:
             resp = method(**{id_param: [res_id]})

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -3,13 +3,14 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from backend.aws_client import get_client
 
 logger = logging.getLogger(__name__)
 from backend.cache import cache
 from backend.config import AWS_ENDPOINT_URL, AWS_REGION, STACKPORT_SERVICES
+from backend.routes.common import get_endpoint_url
 
 router = APIRouter()
 
@@ -118,7 +119,7 @@ def _count_items(resp, response_key: str) -> int:
     return 0
 
 
-def _probe_service(service: str) -> tuple[str, dict]:
+def _probe_service(service: str, endpoint_url: str) -> tuple[str, dict]:
     """Probe a single service and return (service_name, result_dict)."""
     registry_entries = SERVICE_REGISTRY.get(service)
     if not registry_entries:
@@ -127,7 +128,7 @@ def _probe_service(service: str) -> tuple[str, dict]:
     resources: dict[str, int] = {}
     try:
         for resource_type, boto3_service, method_name, response_key in registry_entries:
-            client = get_client(boto3_service)
+            client = get_client(boto3_service, endpoint_url)
             method = getattr(client, method_name)
             kwargs = _METHOD_KWARGS.get((boto3_service, method_name), {})
             try:
@@ -143,8 +144,9 @@ def _probe_service(service: str) -> tuple[str, dict]:
 
 
 @router.get("/stats")
-def get_stats():
-    cached = cache.get("stats")
+def get_stats(endpoint_url: str = Depends(get_endpoint_url)):
+    cache_key = f"{endpoint_url}:stats"
+    cached = cache.get(cache_key)
     if cached is not None:
         return cached
 
@@ -153,7 +155,7 @@ def get_stats():
     total_resources = 0
 
     with ThreadPoolExecutor(max_workers=min(len(enabled_services), 10)) as executor:
-        futures = {executor.submit(_probe_service, svc): svc for svc in enabled_services}
+        futures = {executor.submit(_probe_service, svc, endpoint_url): svc for svc in enabled_services}
         for future in as_completed(futures):
             svc_name, result = future.result()
             services[svc_name] = result
@@ -167,5 +169,5 @@ def get_stats():
         "total_resources": total_resources,
         "uptime_seconds": round(time.time() - _start_time, 1),
     }
-    cache.set("stats", response, ttl=5)
+    cache.set(cache_key, response, ttl=5)
     return response

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,98 @@
+"""Tests for multi-endpoint support."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestEndpoints:
+    """Test endpoint configuration and routing."""
+
+    def test_endpoints_route_returns_list(self, client):
+        """Test /api/endpoints returns endpoint configuration."""
+        response = client.get("/api/endpoints")
+        assert response.status_code == 200
+        data = response.json()
+        assert "endpoints" in data
+        assert isinstance(data["endpoints"], list)
+        assert len(data["endpoints"]) >= 1
+        # Check first endpoint structure
+        endpoint = data["endpoints"][0]
+        assert "name" in endpoint
+        assert "url" in endpoint
+        assert "health" in endpoint
+
+    def test_default_endpoint_configuration(self, client):
+        """Test default endpoint is configured when STACKPORT_ENDPOINTS is not set."""
+        response = client.get("/api/endpoints")
+        data = response.json()
+        # Should have at least one endpoint (default)
+        assert len(data["endpoints"]) >= 1
+        # First endpoint should be "default"
+        assert data["endpoints"][0]["name"] == "default"
+
+    def test_stats_without_endpoint_param(self, client):
+        """Test /api/stats works without endpoint query param (uses default)."""
+        response = client.get("/api/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert "services" in data
+
+    def test_resources_without_endpoint_param(self, client):
+        """Test /api/resources works without endpoint query param (uses default)."""
+        response = client.get("/api/resources/s3")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["service"] == "s3"
+        assert "resources" in data
+
+
+class TestEndpointParsing:
+    """Test STACKPORT_ENDPOINTS parsing."""
+
+    def test_parse_endpoints_from_env(self, monkeypatch):
+        """Test parsing STACKPORT_ENDPOINTS env var."""
+        monkeypatch.setenv("STACKPORT_ENDPOINTS", "local=http://localhost:4566,moto=http://localhost:5000")
+
+        # Re-import to pick up env change
+        import importlib
+
+        import backend.config
+
+        importlib.reload(backend.config)
+
+        assert len(backend.config.ENDPOINTS) == 2
+        assert "local" in backend.config.ENDPOINTS
+        assert "moto" in backend.config.ENDPOINTS
+        assert backend.config.ENDPOINTS["local"] == "http://localhost:4566"
+        assert backend.config.ENDPOINTS["moto"] == "http://localhost:5000"
+
+        # Restore
+        monkeypatch.delenv("STACKPORT_ENDPOINTS")
+        importlib.reload(backend.config)
+
+    def test_default_endpoint_when_not_configured(self, monkeypatch):
+        """Test default endpoint when STACKPORT_ENDPOINTS is not set."""
+        monkeypatch.delenv("STACKPORT_ENDPOINTS", raising=False)
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "http://test:1234")
+
+        import importlib
+
+        import backend.config
+
+        importlib.reload(backend.config)
+
+        assert len(backend.config.ENDPOINTS) == 1
+        assert "default" in backend.config.ENDPOINTS
+        assert backend.config.ENDPOINTS["default"] == "http://test:1234"
+
+        # Restore
+        importlib.reload(backend.config)


### PR DESCRIPTION
## Summary

Adds backend support for connecting to multiple AWS-compatible endpoints simultaneously. This allows teams to run different emulators side-by-side or compare resources across environments.

## Changes

### Configuration

**Environment Variable:**
```bash
# Single endpoint (backward compatible)
AWS_ENDPOINT_URL=http://localhost:4566 stackport

# Multiple endpoints  
STACKPORT_ENDPOINTS='local=http://localhost:4566,moto=http://localhost:5000' stackport
```

### Backend

**New Routes:**
- `GET /api/endpoints` — List configured endpoints with health status

**Updated Routes:**
- `GET /api/stats?endpoint=<name>` — Get stats from specific endpoint
- `GET /api/resources/{service}?endpoint=<name>` — List resources from specific endpoint
- `GET /api/resources/{service}/{type}/{id}?endpoint=<name>` — Get resource details from specific endpoint

**Files Changed:**
- `backend/config.py` — Parse `STACKPORT_ENDPOINTS`, expose `ENDPOINTS` dict and `DEFAULT_ENDPOINT`
- `backend/aws_client.py` — Add `endpoint_url` parameter to `get_client()`, cache by (service, endpoint_url)
- `backend/routes/common.py` (new) — FastAPI dependency for endpoint extraction
- `backend/routes/endpoints.py` (new) — `/api/endpoints` route with health checks
- `backend/routes/stats.py` — Accept endpoint query param, update cache keys
- `backend/routes/resources.py` — Accept endpoint query param, update cache keys
- `backend/main.py` — Register endpoints router

### Tests

**New:**
- `tests/test_endpoints.py` — 6 tests covering endpoint configuration and routing

**Results:**
- All 133 tests pass (127 existing + 6 new)

## Usage Examples

```bash
# List configured endpoints
curl http://localhost:8080/api/endpoints
# {"endpoints": [{"name": "local", "url": "http://localhost:4566", "health": "healthy"}]}

# Get stats from specific endpoint
curl 'http://localhost:8080/api/stats?endpoint=local'

# List S3 buckets from specific endpoint
curl 'http://localhost:8080/api/resources/s3?endpoint=moto'

# Default endpoint (no query param)
curl 'http://localhost:8080/api/stats'
```

## Backward Compatibility

✅ Fully backward compatible:
- If `STACKPORT_ENDPOINTS` is not set, uses `AWS_ENDPOINT_URL` as single "default" endpoint
- Routes without `?endpoint` param use default endpoint
- Existing code calling `get_client(service)` without endpoint param still works

## Implementation Status

**Completed:**
- ✅ Backend endpoint configuration
- ✅ Backend route updates
- ✅ Cache isolation per endpoint
- ✅ Health check endpoint
- ✅ Tests and backward compatibility

**Not Yet Implemented (future PR):**
- ⏳ Frontend endpoint selector UI in header
- ⏳ Frontend API client updates to pass endpoint param
- ⏳ Endpoint persistence in URL query params
- ⏳ Dashboard per-endpoint view

This PR provides the backend foundation. Frontend UI will follow in a separate PR.

Partial implementation of #17