### PR TITLE
fix: add missing fetchResourceTags mock to S3Browser tests

### DIFF
--- a/ui/src/__tests__/S3Browser.test.tsx
+++ b/ui/src/__tests__/S3Browser.test.tsx
@@ -70,6 +70,8 @@ vi.mock('@/lib/api', () => ({
   deleteS3ObjectsBatch: vi.fn(),
   createS3Folder: vi.fn(),
   fetchS3UploadConfig: vi.fn(() => Promise.resolve({ max_upload_bytes: 104857600 })),
+  fetchResourceTags: vi.fn(() => Promise.resolve({ tags: {} })),
+  updateResourceTags: vi.fn(() => Promise.resolve({ success: true })),
 }))
 
 function renderWithBucket(search = '?bucket=my-bucket') {


### PR DESCRIPTION
## Summary
- Add `fetchResourceTags` and `updateResourceTags` mocks to S3Browser test file
- These were missing after bucket-level tag support was added in PR #99, causing 4 test failures in CI

## Test plan
- [x] All 153 frontend tests pass (`npx vitest run`)
- [x] All 193 backend tests pass
- [x] TypeScript typecheck clean
- [x] Build succeeds