### PR TITLE
fix: add localStorage mock to vitest setup

### DIFF
--- a/ui/src/__tests__/setup.ts
+++ b/ui/src/__tests__/setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom/vitest'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = String(value) },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    get length() { return Object.keys(store).length },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })


### PR DESCRIPTION
Closes #108

## Summary

- Adds an in-memory `localStorage` mock to `ui/src/__tests__/setup.ts`
- Fixes 11 failing tests across `useFavorites.test.ts` (8) and `Dashboard.test.tsx` (3)
- jsdom doesn't provide a functional `localStorage` — all calls to `.getItem()`, `.setItem()`, `.clear()` were throwing `TypeError`

## Test plan

- [x] All 163 frontend tests pass (was 152/163)
- [x] TypeScript typecheck clean
- [x] No application code changes — test infrastructure only